### PR TITLE
Separatelogic to read and parse the file. Throw actual error in catch block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "envjoi",
-  "version": "1.0.0",
+  "name": "@twiddler/envjoi",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@twiddler/envjoi",
-  "version": "1.1.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@twiddler/envjoi",
-    "version": "1.1.1",
+    "version": "1.0.2",
     "description": "Webpack plugin for using .env files and validating them with joi",
     "main": "lib/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@twiddler/envjoi",
-    "version": "1.0.1",
+    "version": "1.1.1",
     "description": "Webpack plugin for using .env files and validating them with joi",
     "main": "lib/index.js",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export function envjoi(schema: Joi.ObjectSchema, path = './.env') {
     return new DefinePlugin(prefixedVars)
 }
 
-function readFile(path) {
+function readFile(path: string) {
     try {
         return fs.readFileSync(path, 'utf8')
     } catch (err) {


### PR DESCRIPTION
The logic for reading and parsing the file should be separated into two functions.  
In the catch block of the parse function no error was thrown. This is now corrected.  
The version number was bumped to `1.0.2` as this pull request does not introduce any new features.  
The package-lock.json in the repository also seems outdated so that is also fixed now.